### PR TITLE
Fix for internal links in documentation

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -12,9 +12,9 @@ SAR imagery is affected by artifacts called Speckle. Speckle looks like  granula
 
 `hydrafloods` has implemented a few of these Speckle filter algorithms in the package to help effectively use SAR imagery for image processing, in this case for surface water mapping. Here is a list of Speckle filter algorithms available:
 
- - Lee Sigma: [`hydrafloods.lee_sigma`](/filtering/#hydrafloods.filtering.lee_sigma) ([Lee et al., 2008](https://doi.org/10.1109/TGRS.2008.2002881))
- - Gamma Map: [`hydrafloods.gamma_map`](/filtering/#hydrafloods.filtering.gamma_map) ([Beauchemin et al., 1995](https://doi.org/10.1080/01431169608949067))
- - Refined Lee: [`hydrafloods.refined_lee`](/filtering/#hydrafloods.filtering.refined_lee) ([Lee, 1981](https://doi.org/10.1016/S0146-664X(81)80018-4))
+ - Lee Sigma: [`hydrafloods.lee_sigma`](/hydra-floods/filtering/#hydrafloods.filtering.lee_sigma) ([Lee et al., 2008](https://doi.org/10.1109/TGRS.2008.2002881))
+ - Gamma Map: [`hydrafloods.gamma_map`](/hydra-floods/filtering/#hydrafloods.filtering.gamma_map) ([Beauchemin et al., 1995](https://doi.org/10.1080/01431169608949067))
+ - Refined Lee: [`hydrafloods.refined_lee`](/hydra-floods/filtering/#hydrafloods.filtering.refined_lee) ([Lee, 1981](https://doi.org/10.1016/S0146-664X(81)80018-4))
 
  Here is a brief example of how one might apply these algorithms to SAR data using `hydrafloods`:
 
@@ -79,7 +79,7 @@ print(refined_lee_filtered.getThumbURL(viz_params))
 :-------------------------------:|:-------------------------------:
 ![](img/algos_sar_gammamap.png) | ![](img/algos_sar_refinedlee.png) 
 
-For more information on the filtering algorithms and the specific arguments, please see the [filtering module](/filtering/) API reference
+For more information on the filtering algorithms and the specific arguments, please see the [filtering module](/hydra-floods/filtering/) API reference
 
 
 ## Correction Algorithms
@@ -133,7 +133,7 @@ Original Landsat 8 Image                    | Corrected Landsat 8 Image
 :------------------------------------------:|:---------------------------------------:
 ![](img/algos_optical_terrain_original.png) | ![](img/algos_optical_terrain_flat.png)
 
-We can see that the algorithm corrected the poorly illuminated areas. This function is valid for both the Landsat8 and Sentinel2 imagery. More information on the illumination correction algorithm and the input arguments can be found at the [corrections module](/corrections/#hydrafloods.corrections.illumination_correction) page
+We can see that the algorithm corrected the poorly illuminated areas. This function is valid for both the Landsat8 and Sentinel2 imagery. More information on the illumination correction algorithm and the input arguments can be found at the [corrections module](/hydra-floods/corrections/#hydrafloods.corrections.illumination_correction) page
 
 
 ### Applying slope correction on SAR imagery
@@ -173,7 +173,7 @@ Original Sentinel 1 Image               | Corrected Sentinel 1 Image
 :--------------------------------------:|:-----------------------------------:
 ![](img/algos_sar_terrain_original.png) | ![](img/algos_sar_terrain_flat.png)
 
-We can see that the effects of terrain are mostly removed. Note: the slope correction algorithm calculates area of terrain shadow and layover (i.e. areas that cannot be corrected) and mask those area, hince some transparent areas.  More documentation regarding the slope correction algorithm and the input arguments can be found at the [corrections module](/corrections/#hydrafloods.corrections.slope_correction) page
+We can see that the effects of terrain are mostly removed. Note: the slope correction algorithm calculates area of terrain shadow and layover (i.e. areas that cannot be corrected) and mask those area, hince some transparent areas.  More documentation regarding the slope correction algorithm and the input arguments can be found at the [corrections module](/hydra-floods/corrections/#hydrafloods.corrections.slope_correction) page
 
 ## Generic Water Mapping Algorithms
 
@@ -183,7 +183,7 @@ The goal of `hydrafloods` is to provide efficient, easily accessible surface wat
 - Bmax Otsu: [`hydrafloods.bmax_otsu`](/thresholding/#hydrafloods.thresholding.bmax_otsu) ([Cao et al.,2019](https://doi.org/10.3390/w11040786); [Markert et al., 2020](https://doi.org/10.3390/rs12152469))
 - KMeans Extent: [`hydrafloods.kmeans_extent`](/thresholding/#hydrafloods.thresholding.kmeans_extent) ([Chang et al., 2020](https://doi.org/10.1016/j.rse.2020.111732))
 
-To begin, we will access optical and SAR data for a coincident time period following the example from [Using Datasets](/using-datasets/):
+To begin, we will access optical and SAR data for a coincident time period following the example from [Using Datasets](/hydra-floods/using-datasets/):
 
 ```python
 # area where overlap is known
@@ -233,7 +233,7 @@ sar_viz = {
 }
 ```
 
-Now that we have our data here we will highlight how to use some generic surface water mapping algorithms, specifically the [`edge_otsu()`](/thresholding/#hydrafloods.thresholding.edge_otsu) algorithm:
+Now that we have our data here we will highlight how to use some generic surface water mapping algorithms, specifically the [`edge_otsu()`](/hydra-floods/thresholding/#hydrafloods.thresholding.edge_otsu) algorithm:
 
 ```python
 # apply the edge otsu algorithm on the MNDWI optical index
@@ -271,6 +271,6 @@ print(sar_water.getThumbURL(water_viz))
 :------------------------------------:|:---------------------------------:
 ![](img/algos_water_optical_edge.png) | ![](img/algos_water_sar_edge.png) 
 
-This is just one example of surface water mapping and there are additional water mapping algorithms as mentioned above. More documentation regarding the water mapping functions and the input arguments can be found at the [thresholding module](/thresholding/)
+This is just one example of surface water mapping and there are additional water mapping algorithms as mentioned above. More documentation regarding the water mapping functions and the input arguments can be found at the [thresholding module](/hydra-floods/thresholding/)
 
 If there are other algorithms you would like to see in the `hydrafloods` package, please file an [issue](https://github.com/Servir-Mekong/hydra-floods/issues) with specifics (and hopefully a link to the paper) on our GitHub repo.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ import hydrafloods as hf
 
 ## Get a `hf.Dataset`
 
-You can access commonly used image collections on Earth Engine as a [`hydrafloods.Dataset`](/datasets/) to quickly filter by space and time as well as apply pre-written QA masking functions.
+You can access commonly used image collections on Earth Engine as a [`hydrafloods.Dataset`](/hydra-floods/datasets/) to quickly filter by space and time as well as apply pre-written QA masking functions.
 
 ```python
 # define a geographic region
@@ -39,12 +39,12 @@ ee_collection = s1.collection
 The `hydrafloods.Dataset` object is a wrapper around an `ee.ImageCollection` by applying the spatial and temporal filtering upon initialization.
 This provides a quick and consistent access to imagery. The `Dataset` class also provides utility functionality to make working with and managing multiple image collections less verbose.
 
-There are many ways to interface with datasets (i.e. ImageCollections) using `hydrafloods`, more examples on merging or joining datasets can be found on the [Using Dataset class](/using-datasets/) page.
+There are many ways to interface with datasets (i.e. ImageCollections) using `hydrafloods`, more examples on merging or joining datasets can be found on the [Using Dataset class](/hydra-floods/using-datasets/) page.
 
 
 ## Image processing
 
-The main purpose of `hydrafloods` is to lower the barrier to creating high-quality surface water maps, this requires image processing. Although the Dataset class wraps an Earth Engine image collection we can apply image processing functions using [`apply_func()`](/datasets/#hydrafloods.datasets.Dataset.apply_func) by passing a function object. 
+The main purpose of `hydrafloods` is to lower the barrier to creating high-quality surface water maps, this requires image processing. Although the Dataset class wraps an Earth Engine image collection we can apply image processing functions using [`apply_func()`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.apply_func) by passing a function object. 
 
 This method wraps a function that accepts an image as the first argument (which most `hydrafloods` image processing algorithms do) and maps it over the collection. For example, we would like to apply a speckle filter algorithm on SAR imagery. We can easily do this with the following code.
 
@@ -54,7 +54,7 @@ This method wraps a function that accepts an image as the first argument (which 
 filtered = s1.apply_func(hf.gamma_map)
 ```
 
-The previous example is synonymous with using `s1.collection = s1.collection.map(hf.gamma_map)` which access the image collection, applies the function, and sets the results to the `s1.collection` property. Although this technically works, using the `apply_func()` method is advantageous and preferred as it allows us to pass arbitrary keyword parameters to functions which we want to apply. For example, the water mapping algorithms found in [`hydrafloods.thresholding`](/thresholding/) take many keyword parameters and we can customize function as in the following example.
+The previous example is synonymous with using `s1.collection = s1.collection.map(hf.gamma_map)` which access the image collection, applies the function, and sets the results to the `s1.collection` property. Although this technically works, using the `apply_func()` method is advantageous and preferred as it allows us to pass arbitrary keyword parameters to functions which we want to apply. For example, the water mapping algorithms found in [`hydrafloods.thresholding`](/hydra-floods/thresholding/) take many keyword parameters and we can customize function as in the following example.
 
 ```python
 # apply the edge otsu surface water mapping 
@@ -74,12 +74,12 @@ It should be noted that using the `apply_func()` method will return a `hydrafloo
 water_img = water_maps.collection.reduce("mode")
 ```
 
-There are a variety of image processing functions available in `hydrafloods`, more information on specific algorithms can be found on the [Algorithms](/algorithms/) page.
+There are a variety of image processing functions available in `hydrafloods`, more information on specific algorithms can be found on the [Algorithms](/hydra-floods/algorithms/) page.
 
 
 ## Time series processing
 
-In addition to image processing, processing data in time is valuable. Therefore, `hydrafloods` has a specific module for time series processing, [`hydrafloods.timeseries`](/timeseries/), specifically for processing stacks of imagery in time.
+In addition to image processing, processing data in time is valuable. Therefore, `hydrafloods` has a specific module for time series processing, [`hydrafloods.timeseries`](/hydra-floods/timeseries/), specifically for processing stacks of imagery in time.
 
 ```python
 # import in the timeseries module
@@ -108,7 +108,7 @@ harmonics_weights = timeseries.fit_harmonic_trend(
 )
 ```
 
-The result from [`fit_harmonic_trend()`](/timeseries/#hydrafloods.timeseries.fit_harmonic_trend) will be an image with many bands. Some bands are the coefficeint weights for prediction (i.e. cos_1, sin_1, or time), others can be awareness information such as number of valid observations used (i.e. n). So we will filter out the coefficient weight bands we need which are cos_n, sin_n and time which start with either "c", "t", or "s". Then get a dummy image with time information and apply the prediction.
+The result from [`fit_harmonic_trend()`](/hydra-floods/timeseries/#hydrafloods.timeseries.fit_harmonic_trend) will be an image with many bands. Some bands are the coefficeint weights for prediction (i.e. cos_1, sin_1, or time), others can be awareness information such as number of valid observations used (i.e. n). So we will filter out the coefficient weight bands we need which are cos_n, sin_n and time which start with either "c", "t", or "s". Then get a dummy image with time information and apply the prediction.
 
 ```python
 # extract bands needed for prediction
@@ -126,12 +126,12 @@ prediction = (
 )
 ```
 
-Time series functionality in `hydrafloods` is focused around modeling data in time, more information on the functions can be found in the [timeseries module API reference](/timeseries/)
+Time series functionality in `hydrafloods` is focused around modeling data in time, more information on the functions can be found in the [timeseries module API reference](/hydra-floods/timeseries/)
 
 
 ## Machine Learning
 
-`hydrafloods` also has a specific module for machine learning workflows with Earth Engine, [`hydrafloods.ml`](/ml/). 
+`hydrafloods` also has a specific module for machine learning workflows with Earth Engine, [`hydrafloods.ml`](/hydra-floods/ml/). 
 
 ```python
 # import in the ml module
@@ -198,4 +198,4 @@ s1_norm = s1_features.apply_func(
 predicted = s1_norm.apply_func(lambda x: x.classify(rf))
 ```
 
-Again, most of the functionality around the `hydrafloods.ml` module is to make end-to-end machine learning work flows more straightforward. Please see the [ml module](/ml/) documentation for information on functions.
+Again, most of the functionality around the `hydrafloods.ml` module is to make end-to-end machine learning work flows more straightforward. Please see the [ml module](/hydra-floods/ml/) documentation for information on functions.

--- a/docs/using-datasets.md
+++ b/docs/using-datasets.md
@@ -56,12 +56,12 @@ print(isinstance(lc8.collection, ee.ImageCollection))
 
 Really, one can think of the custom `qa()` method as a preprocessing step that you would like to happen on *all* images in the dataset so it is not just restricted to specific sensors as seen in a later section.
 
-- Sentinel 1: [`hydrafloods.Sentinel1`](/datasets/#hydrafloods.datasets.Sentinel1)
-- Sentinel 2: [`hydrafloods.Sentinel2`](/datasets/#hydrafloods.datasets.Sentinel2)
-- Landsat 8: [`hydrafloods.Landsat8`](/datasets/#hydrafloods.datasets.Landsat8)
-- Landsat 7: [`hydrafloods.Landsat7`](/datasets/#hydrafloods.datasets.Landsat7)
-- VIIRS: [`hydrafloods.Viirs`](/datasets/#hydrafloods.datasets.Viirs)
-- MODIS: [`hydrafloods.Modis`](/datasets/#hydrafloods.datasets.Modis)
+- Sentinel 1: [`hydrafloods.Sentinel1`](/hydra-floods/datasets/#hydrafloods.datasets.Sentinel1)
+- Sentinel 2: [`hydrafloods.Sentinel2`](/hydra-floods/datasets/#hydrafloods.datasets.Sentinel2)
+- Landsat 8: [`hydrafloods.Landsat8`](/hydra-floods/datasets/#hydrafloods.datasets.Landsat8)
+- Landsat 7: [`hydrafloods.Landsat7`](/hydra-floods/datasets/#hydrafloods.datasets.Landsat7)
+- VIIRS: [`hydrafloods.Viirs`](/hydra-floods/datasets/#hydrafloods.datasets.Viirs)
+- MODIS: [`hydrafloods.Modis`](/hydra-floods/datasets/#hydrafloods.datasets.Modis)
 
 To provide an example of using the internal `qa()` method and not we can redefine the Landsat 8 collection from before but with setting `use_qa` to `False`
 
@@ -101,7 +101,7 @@ We can clearly see the image on the left has clouds and cloud shadows masked and
 
 ## Creating a Dataset from a computed `ee.ImageCollection`
 
-While HYDRAFloods provides some specialized Dataset classes for users to immediately access, there are often times when a user would like to use their own Image Collection. To this end, a method is available for users to create a dataset directly from an ee.ImageCollection object, [`hf.Dataset.from_imgcollection`](/datasets/#hydrafloods.datasets.Dataset.from_imgcollection). This allows Dataset objects to be created from image collections that have been filtered or with additional computation applied. Here is a quick example grabbing the public Planet SkySat data, filtering to the United States, and calculating NDVI:
+While HYDRAFloods provides some specialized Dataset classes for users to immediately access, there are often times when a user would like to use their own Image Collection. To this end, a method is available for users to create a dataset directly from an ee.ImageCollection object, [`hf.Dataset.from_imgcollection`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.from_imgcollection). This allows Dataset objects to be created from image collections that have been filtered or with additional computation applied. Here is a quick example grabbing the public Planet SkySat data, filtering to the United States, and calculating NDVI:
 
 ```python
 us = hf.country_bbox("United States")
@@ -124,7 +124,7 @@ It should be noted that hydrafloods will attempt to call `.getInfo()` from the `
 
 ## Applying a function
 
-As we saw in the [Getting Stated](/getting-started/#image-processing) page, we can apply image processing functions using [`apply_func()`](/datasets/#hydrafloods.datasets.Dataset.apply_func) by passing a function object or any keyword parameters. This method wraps a function that accepts an image as the first argument (which most `hydrafloods` image processing algorithms do) and maps it over the collection. For example, if want to create a water map using Landsat 8, we will calculate a water index and then apply a thresholding algorithm: 
+As we saw in the [Getting Stated](/hydra-floods/getting-started/#image-processing) page, we can apply image processing functions using [`apply_func()`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.apply_func) by passing a function object or any keyword parameters. This method wraps a function that accepts an image as the first argument (which most `hydrafloods` image processing algorithms do) and maps it over the collection. For example, if want to create a water map using Landsat 8, we will calculate a water index and then apply a thresholding algorithm: 
 
 ```python
 region = hf.country_bbox("Cambodia")
@@ -167,7 +167,7 @@ water_img.getThumbURL({
 
 ## Merging Datasets
 
-One of the simpilest ways to combine datasets is to merge. This takes the imagery in one collection and concatenates it with the original collection. We can use the [`merge()`](/datasets/#hydrafloods.datasets.Dataset.merge) method to accomplish this. Additionally, the `merge()` method automatically sorts the image collections by date so we can start using dense time series right away. Here is an example of merging Landat8 and Sentinel2 datasets together:
+One of the simpilest ways to combine datasets is to merge. This takes the imagery in one collection and concatenates it with the original collection. We can use the [`merge()`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.merge) method to accomplish this. Additionally, the `merge()` method automatically sorts the image collections by date so we can start using dense time series right away. Here is an example of merging Landat8 and Sentinel2 datasets together:
 
 ```python
 lc8 = hf.Landsat8(region,start_time,end_time)
@@ -183,7 +183,7 @@ print(merged.n_images)
 
 ## Joining Datasets
 
-Joining datasets is another way to bring together two datasets but by looking at coincident imagery and combines the bands into one image. Whereas merge combined the two collections irrespective of space time overlap, [`join()`](/datasets/#hydrafloods.datasets.Dataset.join) looks for overlapping data in space and time and will return only data that overlaps with the bands combined. Furthermore, the resulting images will be clipped to the overlapping region. This functionality is really helpful when looking for coincident data from multiple sensors.
+Joining datasets is another way to bring together two datasets but by looking at coincident imagery and combines the bands into one image. Whereas merge combined the two collections irrespective of space time overlap, [`join()`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.join) looks for overlapping data in space and time and will return only data that overlaps with the bands combined. Furthermore, the resulting images will be clipped to the overlapping region. This functionality is really helpful when looking for coincident data from multiple sensors.
 
 ```python
 lc8 = hf.Landsat8(region,start_time,end_time)
@@ -232,7 +232,7 @@ print(sar_thumb)
 
 ## Temporal aggregation
 
-A common workflow is merging data and make composites for individual dates that data is available. A good example of this is the MODIS sensor that is onboard the Terra and Aqua satellite. We can create daily composites of the imagery by merging the datasets then looping over each day to mosaic the data. `hydrafloods` has a method [`aggregate_time()`](/datasets/#hydrafloods.datasets.Dataset.aggregate_time) to do the mosaicing sequentially in time. Here we create a combined MODIS Terra and Aqua dataset.
+A common workflow is merging data and make composites for individual dates that data is available. A good example of this is the MODIS sensor that is onboard the Terra and Aqua satellite. We can create daily composites of the imagery by merging the datasets then looping over each day to mosaic the data. `hydrafloods` has a method [`aggregate_time()`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.aggregate_time) to do the mosaicing sequentially in time. Here we create a combined MODIS Terra and Aqua dataset.
 
 ```python
 # define new time range
@@ -287,7 +287,7 @@ As seen, this method allows for customization of when to start aggregations and 
 
 As seen in the ["Applying a function"](#applying-a-function) section, we can easily process imagery by passing individual functions into  `.apply_func()`. While this method of writing the computation is easy to read syntaxually, it is however inefficient for for Earth Engien to apply the computations. This is because each function passed through `.apply_func()` applies the function to all imagery in the Dataset. For example, if there are three functions you want to apply, then it will loop through all of the imagery three times. This can cause computation timeout or memory errors on Earth Engine's side if there is a lot to compute using multiple mapped functions.
 
-The [`.pipe()`](/datasets/#hydrafloods.datasets.Dataset.pipe) method allows for users to apply multiple functions to a Dataset with only one pass through the imagery. This is the preferred method to chain together multiple functions. For example, if we want to create water maps from Landsat 8 we would calculate a water index (e.g. MNDWI) then apply the water mapping algorithm. Here we can tell `.pipe()` the order of functions to apply and the arguments (if any) and it will nest the functions into one to map over.
+The [`.pipe()`](/hydra-floods/datasets/#hydrafloods.datasets.Dataset.pipe) method allows for users to apply multiple functions to a Dataset with only one pass through the imagery. This is the preferred method to chain together multiple functions. For example, if we want to create water maps from Landsat 8 we would calculate a water index (e.g. MNDWI) then apply the water mapping algorithm. Here we can tell `.pipe()` the order of functions to apply and the arguments (if any) and it will nest the functions into one to map over.
 
 ```python
 
@@ -409,4 +409,4 @@ print(first_img.getThumbURL(viz_params))
 
 In this example of a custom dataset class for GOES16 imagery, the `qa()` method definition is more for preprocessing to scale the imagery. A custom cloud/shadow masking workflow can easily be included and applied on the imagery. Now we are ready to use our custom GOES16 imagery with the rest of the `hydrafloods` functions!
 
-More detailed information on the `hydrafloods.Dataset` class along with it's method fucntionality and arguments can be found in the [datasets module](/datasets/) API reference. 
+More detailed information on the `hydrafloods.Dataset` class along with it's method fucntionality and arguments can be found in the [datasets module](/hydra-floods/datasets/) API reference. 

--- a/docs/workflow-example.md
+++ b/docs/workflow-example.md
@@ -75,7 +75,7 @@ dswfp.export_surface_water_harmonics(
 
 ### 3. Export daily water map
 
-Now that we have our data exported and ready to use, we can begin predicting daily surface water maps. Here we provide a date that will want to estimate water for and this algorithm will estimate a water index based on the long-term harmonic trend while correcting that with recent observations. This kicks off two exports, one for the fused water index and another for the water map. The final water index is segmented using on of the [thresholding](/thresholding/) algorithms.
+Now that we have our data exported and ready to use, we can begin predicting daily surface water maps. Here we provide a date that will want to estimate water for and this algorithm will estimate a water index based on the long-term harmonic trend while correcting that with recent observations. This kicks off two exports, one for the fused water index and another for the water map. The final water index is segmented using on of the [thresholding](/hydra-floods/thresholding/) algorithms.
 
 ```python
 target_date = "2020-10-31"


### PR DESCRIPTION
:wave: Hi, sorry for the tiny PR but this seemed like a good excuse to try the new `.` web-editor functionality in GitHub.

I noticed the internal links on the hosted documentation were broken (such as the link on [this page](https://servir-mekong.github.io/hydra-floods/using-datasets/) to the Sentinel-1 class). It appeared to me as if the links were all just missing a `/hydra-floods/` at the beginning. So for the Sentinel-1 link example the broken link was [https://servir-mekong.github.io/datasets/#hydrafloods.datasets.Sentinel1](https://servir-mekong.github.io/datasets/#hydrafloods.datasets.Sentinel1) and revised it becomes [https://servir-mekong.github.io/hydra-floods/datasets/#hydrafloods.datasets.Sentinel1](https://servir-mekong.github.io/hydra-floods/datasets/#hydrafloods.datasets.Sentinel1).

Again, I was trying this out in the new web-editor so I haven't actually tested this locally, but I figured this was a pretty safe change to make (just hyperlinks not actual functionality) without testing.