### PR TITLE
Support for exporting to Google Drive

### DIFF
--- a/hydrafloods/geeutils.py
+++ b/hydrafloods/geeutils.py
@@ -53,7 +53,7 @@ def get_geoms(img):
 def export_image(
     image,
     region,
-    asset_id,
+    asset_id=None,
     description=None,
     scale=1000,
     crs="EPSG:4326",
@@ -208,12 +208,13 @@ def batch_export(
         export_image(
             img,
             region,
-            exportName,
+            assed_id=exportName,
             description=description,
             scale=scale,
             crs=crs,
             pyramiding=pyramiding,
-            export_type=export_type
+            export_type=export_type,
+            folder=folder,
         )
 
     return

--- a/hydrafloods/tests/test_geeutils.py
+++ b/hydrafloods/tests/test_geeutils.py
@@ -1,0 +1,67 @@
+"""Unit tests for geeutils.py."""
+import pytest
+import unittest.mock as mock
+
+import ee
+import hydrafloods as hf
+
+
+def test_export_image_toAsset():
+    """Test that the toAsset export gets called by default."""
+    # mock ee export functionality
+    ee.batch.Export.image.toAsset = mock.MagicMock()
+    ee.Image = mock.MagicMock()
+    ee.Geometry = mock.MagicMock()
+    # call export function
+    hf.geeutils.export_image(ee.Image, ee.Geometry, 'assid', 'desc')
+    # assert that the ee.export call within the function was called
+    assert ee.batch.Export.image.toAsset.call_count == 1
+
+
+def test_export_image_toDrive():
+    """Test that the toDrive export gets called when specified."""
+    # mock ee export functionality
+    ee.batch.Export.image.toDrive = mock.MagicMock()
+    ee.Image = mock.MagicMock()
+    ee.Geometry = mock.MagicMock()
+    # call export function
+    hf.geeutils.export_image(ee.Image, ee.Geometry, 'assid', 'desc',
+                             export_type='toDrive')
+    # assert that the ee.export call within the function was called
+    assert ee.batch.Export.image.toDrive.call_count == 1
+
+
+def test_export_image_export_type_invalid_string():
+    """Test ValueError for export_type."""
+    # mock ee export functionality
+    ee.batch.Export.image.toAsset = mock.MagicMock()
+    ee.Image = mock.MagicMock()
+    ee.Geometry = mock.MagicMock()
+    # call export function
+    with pytest.raises(ValueError):
+        hf.geeutils.export_image(ee.Image, ee.Geometry, 'assid', 'desc',
+                                 export_type='invalid string')
+
+
+def test_export_image_export_type_invalid_type():
+    """Test TypeError for export_type."""
+    # mock ee export functionality
+    ee.batch.Export.image.toAsset = mock.MagicMock()
+    ee.Image = mock.MagicMock()
+    ee.Geometry = mock.MagicMock()
+    # call export function
+    with pytest.raises(TypeError):
+        hf.geeutils.export_image(ee.Image, ee.Geometry, 'assid', 'desc',
+                                 export_type=123)
+
+
+def test_export_image_folder_invalid_type():
+    """Test TypeError for folder."""
+    # mock ee export functionality
+    ee.batch.Export.image.toAsset = mock.MagicMock()
+    ee.Image = mock.MagicMock()
+    ee.Geometry = mock.MagicMock()
+    # call export function
+    with pytest.raises(TypeError):
+        hf.geeutils.export_image(ee.Image, ee.Geometry, 'assid', 'desc',
+                                 folder=123)


### PR DESCRIPTION
This PR expands the functionality of the `export_image` function to allow images to be exported to Google Drive using the Earth Engine function call `ee.Batch.Export.image.toDrive`. Previous functionality is unchanged and default behavior should match what the function was doing prior to these changes. This PR aims to close #24.

Key changes:
- `asset_id` is now an optional key-word argument as it is not needed for exporting to Drive
- `export_type` is an optional key-word argument that defaults to 'toAsset' which reproduces old functionality, but can be specified as 'toDrive' in which case the `ee.Batch.Export.image.toDrive` function is used
- `folder` is an optional key-word argument that can be used to specify the Drive folder to export the image to
- Creation of `test_geeutils.py` file to add some unit tests which ensure errors are raised and the different export functions are called as expected